### PR TITLE
Feature/secure microsoft oauth

### DIFF
--- a/apps/authentication/authentication.py
+++ b/apps/authentication/authentication.py
@@ -1,0 +1,126 @@
+import json
+import logging
+import urllib.request
+
+import jwt
+from django.conf import settings
+from jwt import PyJWTError
+from jwt.algorithms import RSAAlgorithm
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from rest_framework.exceptions import AuthenticationFailed
+
+from apps.authentication.services import upsert_microsoft_user
+from apps.common.redis_client import redis_client
+
+logger = logging.getLogger(__name__)
+
+JWKS_CACHE_KEY = "microsoft:jwks"
+JWKS_CACHE_TTL = 3600  # seconds
+
+
+def _fetch_jwks() -> dict:
+    cached = redis_client.get(JWKS_CACHE_KEY)
+    if cached:
+        try:
+            return json.loads(cached)
+        except json.JSONDecodeError:
+            # fallthrough to refetch
+            pass
+
+    url = f"https://login.microsoftonline.com/{settings.MICROSOFT_TENANT_ID}/discovery/v2.0/keys"
+    with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310 - trusted Microsoft URL
+        body = resp.read()
+        jwks = json.loads(body)
+
+    redis_client.setex(JWKS_CACHE_KEY, JWKS_CACHE_TTL, json.dumps(jwks))
+    return jwks
+
+
+def _get_public_key(token: str) -> str | None:
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except PyJWTError:
+        return None
+
+    kid = unverified_header.get("kid")
+    if not kid:
+        return None
+
+    jwks = _fetch_jwks()
+    keys = jwks.get("keys", [])
+    for key in keys:
+        if key.get("kid") == kid:
+            return RSAAlgorithm.from_jwk(json.dumps(key))
+    return None
+
+
+def _is_microsoft_issuer(issuer: str) -> bool:
+    return issuer.startswith("https://login.microsoftonline.com/")
+
+
+class MicrosoftBearerAuthentication(BaseAuthentication):
+    """
+    DRF authentication class that validates Microsoft access tokens (Bearer).
+
+    It leaves existing JWT authentication untouched; only triggers when the token
+    issuer is Microsoft.
+    """
+
+    keyword = "Bearer"
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+        if not auth or auth[0].lower() != self.keyword.lower().encode():
+            return None
+        if len(auth) == 1:
+            raise AuthenticationFailed("Invalid Authorization header. No credentials provided.")
+        if len(auth) > 2:
+            raise AuthenticationFailed("Invalid Authorization header. Token string should not contain spaces.")
+
+        raw_token = auth[1].decode("utf-8")
+
+        # Quick unverified decode to decide if this is a Microsoft token; if not, let other auth classes handle it.
+        try:
+            unverified_claims = jwt.decode(raw_token, options={"verify_signature": False})
+        except PyJWTError:
+            return None
+
+        issuer = unverified_claims.get("iss", "")
+        if not _is_microsoft_issuer(issuer):
+            return None  # not Microsoft -> let other authenticators run
+
+        expected_issuer = f"https://login.microsoftonline.com/{settings.MICROSOFT_TENANT_ID}/v2.0"
+        audiences = [settings.MICROSOFT_CLIENT_ID]
+        api_audience = getattr(settings, "MICROSOFT_API_AUDIENCE", "")
+        if api_audience:
+            audiences.append(api_audience)
+
+        public_key = _get_public_key(raw_token)
+        if not public_key:
+            raise AuthenticationFailed("Unable to fetch Microsoft signing key.")
+
+        try:
+            claims = jwt.decode(
+                raw_token,
+                key=public_key,
+                algorithms=["RS256"],
+                audience=audiences,
+                issuer=expected_issuer,
+            )
+        except PyJWTError as exc:
+            logger.info("Microsoft token validation failed: %s", exc)
+            raise AuthenticationFailed("Invalid Microsoft access token.") from exc
+
+        email = claims.get("preferred_username") or claims.get("email")
+        microsoft_id = claims.get("oid")
+        first_name = claims.get("given_name", "")
+        last_name = claims.get("family_name", "")
+
+        user, _ = upsert_microsoft_user(
+            email=email,
+            microsoft_id=microsoft_id,
+            first_name=first_name,
+            last_name=last_name,
+        )
+
+        return user, raw_token

--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -137,6 +137,8 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
         return value
 
 
-class MicrosoftAuthCallbackSerializer(serializers.Serializer):
-    code = serializers.CharField(required=True)
-    state = serializers.CharField(required=False, allow_blank=True)
+class MicrosoftAuthTokenSerializer(serializers.Serializer):
+    """Serializer for exchanging Microsoft authorization code for tokens."""
+
+    code = serializers.CharField(required=True, help_text="Authorization code from Microsoft redirect")
+    state = serializers.CharField(required=True, help_text="State parameter for CSRF protection")

--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -137,8 +137,5 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
         return value
 
 
-class MicrosoftAuthTokenSerializer(serializers.Serializer):
-    """Serializer for exchanging Microsoft authorization code for tokens."""
-
-    code = serializers.CharField(required=True, help_text="Authorization code from Microsoft redirect")
-    state = serializers.CharField(required=True, help_text="State parameter for CSRF protection")
+# Microsoft OAuth: No serializers needed - frontend handles full flow via MSAL.
+# Backend validates Microsoft Bearer tokens via MicrosoftBearerAuthentication class.

--- a/apps/authentication/services.py
+++ b/apps/authentication/services.py
@@ -281,6 +281,7 @@ def get_microsoft_auth_url() -> dict:
         scopes=["User.Read"],
         redirect_uri=settings.MICROSOFT_REDIRECT_URI,
         state=state,
+        prompt="select_account",
     )
 
     return {

--- a/apps/authentication/services.py
+++ b/apps/authentication/services.py
@@ -4,7 +4,6 @@ import secrets
 from io import BytesIO
 from typing import TYPE_CHECKING
 
-import msal
 import pyotp
 import qrcode
 from django.conf import settings
@@ -254,88 +253,17 @@ def disable_mfa(user, password: str) -> dict:
 # ============================================================================
 # Microsoft OAuth Authentication
 # ============================================================================
+# Frontend handles the full OAuth 2.0 Authorization Code Flow with PKCE via MSAL.
+# Backend validates Microsoft Bearer tokens via MicrosoftBearerAuthentication class.
+# Only upsert_microsoft_user is needed here to create/update users from token claims.
 
 
-def get_msal_app():
-    """Get MSAL confidential client application."""
-    return msal.ConfidentialClientApplication(
-        client_id=settings.MICROSOFT_CLIENT_ID,
-        client_credential=settings.MICROSOFT_CLIENT_SECRET,
-        authority=f"https://login.microsoftonline.com/{settings.MICROSOFT_TENANT_ID}",
-    )
+def upsert_microsoft_user(email: str, microsoft_id: str, first_name: str = "", last_name: str = ""):
+    """Create or update a user based on Microsoft identity token claims.
 
-
-def get_microsoft_auth_url() -> dict:
-    """Generate Microsoft OAuth authorization URL."""
-    app = get_msal_app()
-
-    # Generate a random state for CSRF protection
-    state = secrets.token_urlsafe(32)
-
-    # Store state in Redis for validation (5 minute TTL)
-    redis_client.setex(f"oauth:state:{state}", 300, "valid")
-
-    # Generate the authorization URL
-    # Note: MSAL automatically adds openid, profile, offline_access scopes
-    auth_url = app.get_authorization_request_url(
-        scopes=["User.Read"],
-        redirect_uri=settings.MICROSOFT_REDIRECT_URI,
-        state=state,
-        prompt="select_account",
-    )
-
-    return {
-        "auth_url": auth_url,
-        "state": state,
-    }
-
-
-def handle_microsoft_callback(code: str, state: str) -> dict:
-    """Handle Microsoft OAuth token exchange and authenticate/create user.
-
-    Args:
-        code: Authorization code from Microsoft redirect
-        state: State parameter for CSRF protection (required)
-
-    Returns:
-        Dict with JWT tokens or MFA challenge
-
-    Raises:
-        ValidationError: If state is invalid/expired or authentication fails
+    Called by MicrosoftBearerAuthentication when validating Microsoft access tokens.
+    Enforces *.utm.md domain policy.
     """
-    # Strict state validation (CSRF protection)
-    if not state:
-        raise exceptions.ValidationError({"error": "State parameter is required"})
-
-    stored_state = redis_client.get(f"oauth:state:{state}")
-    if not stored_state:
-        raise exceptions.ValidationError({"error": "Invalid or expired OAuth state"})
-
-    # Delete state immediately (one-time use)
-    redis_client.delete(f"oauth:state:{state}")
-
-    app = get_msal_app()
-
-    # Exchange authorization code for tokens
-    # Note: scopes must match those used in get_authorization_request_url
-    result = app.acquire_token_by_authorization_code(
-        code=code,
-        scopes=["User.Read"],
-        redirect_uri=settings.MICROSOFT_REDIRECT_URI,
-    )
-
-    if "error" in result:
-        error_desc = result.get("error_description", result.get("error", "Unknown error"))
-        raise exceptions.ValidationError({"error": f"Microsoft authentication failed: {error_desc}"})
-
-    # Extract user info from ID token claims
-    id_token_claims = result.get("id_token_claims", {})
-
-    email = id_token_claims.get("preferred_username") or id_token_claims.get("email")
-    microsoft_id = id_token_claims.get("oid")  # Object ID - unique Microsoft user identifier
-    first_name = id_token_claims.get("given_name", "")
-    last_name = id_token_claims.get("family_name", "")
-
     if not email:
         raise exceptions.ValidationError({"error": "Could not retrieve email from Microsoft account"})
 
@@ -346,7 +274,6 @@ def handle_microsoft_callback(code: str, state: str) -> dict:
     if not email.lower().endswith("utm.md"):
         raise exceptions.ValidationError({"error": "Registration allowed only with *.utm.md email."})
 
-    # Find or create user
     user, created = User.objects.get_or_create(
         email=email,
         defaults={
@@ -359,7 +286,6 @@ def handle_microsoft_callback(code: str, state: str) -> dict:
     )
 
     if not created:
-        # Existing user - update OAuth info if not set
         updated_fields = []
 
         if user.oauth_provider == OAuthProvider.NONE:
@@ -367,7 +293,6 @@ def handle_microsoft_callback(code: str, state: str) -> dict:
             user.oauth_id = microsoft_id
             updated_fields.extend(["oauth_provider", "oauth_id"])
 
-        # Update name if empty
         if not user.first_name and first_name:
             user.first_name = first_name
             updated_fields.append("first_name")
@@ -375,7 +300,6 @@ def handle_microsoft_callback(code: str, state: str) -> dict:
             user.last_name = last_name
             updated_fields.append("last_name")
 
-        # Mark as verified since they authenticated via Microsoft
         if not user.is_verified:
             user.is_verified = True
             updated_fields.append("is_verified")
@@ -383,16 +307,4 @@ def handle_microsoft_callback(code: str, state: str) -> dict:
         if updated_fields:
             user.save(update_fields=updated_fields)
 
-    # Check if MFA is required
-    mfa_payload = handle_mfa_flow(user)
-    if mfa_payload:
-        return mfa_payload
-
-    # Generate JWT tokens
-    tokens = generate_tokens_for_user(user)
-
-    return {
-        **tokens,
-        "created": created,
-        "message": "Account created via Microsoft" if created else "Logged in via Microsoft",
-    }
+    return user, created

--- a/apps/authentication/urls.py
+++ b/apps/authentication/urls.py
@@ -10,8 +10,8 @@ from .views import (
     MFASetupConfirmView,
     MFASetupStartView,
     MFAVerifyView,
-    MicrosoftAuthCallbackView,
     MicrosoftAuthStartView,
+    MicrosoftAuthTokenView,
     PasswordChangeView,
     PasswordResetConfirmView,
     PasswordResetRequestView,
@@ -37,6 +37,6 @@ urlpatterns = [
     path("mfa/verify", MFAVerifyView.as_view(), name="mfa_verify"),
     path("mfa/disable", MFADisableView.as_view(), name="mfa_disable"),
     # Microsoft OAuth
-    path("microsoft", MicrosoftAuthStartView.as_view(), name="microsoft_auth_start"),
-    path("microsoft/callback", MicrosoftAuthCallbackView.as_view(), name="microsoft_auth_callback"),
+    path("microsoft/", MicrosoftAuthStartView.as_view(), name="microsoft_auth_start"),
+    path("microsoft/token/", MicrosoftAuthTokenView.as_view(), name="microsoft_auth_token"),
 ]

--- a/apps/authentication/urls.py
+++ b/apps/authentication/urls.py
@@ -10,8 +10,6 @@ from .views import (
     MFASetupConfirmView,
     MFASetupStartView,
     MFAVerifyView,
-    MicrosoftAuthStartView,
-    MicrosoftAuthTokenView,
     PasswordChangeView,
     PasswordResetConfirmView,
     PasswordResetRequestView,
@@ -36,7 +34,6 @@ urlpatterns = [
     path("mfa/setup/regenerate", MFABackupCodesRegenerateView.as_view(), name="mfa_backup_codes_regenerate"),
     path("mfa/verify", MFAVerifyView.as_view(), name="mfa_verify"),
     path("mfa/disable", MFADisableView.as_view(), name="mfa_disable"),
-    # Microsoft OAuth
-    path("microsoft/", MicrosoftAuthStartView.as_view(), name="microsoft_auth_start"),
-    path("microsoft/token/", MicrosoftAuthTokenView.as_view(), name="microsoft_auth_token"),
+    # Microsoft OAuth: Frontend handles full flow via MSAL, backend validates Bearer tokens
+    # via MicrosoftBearerAuthentication class - no endpoints needed
 ]

--- a/apps/authentication/utils.py
+++ b/apps/authentication/utils.py
@@ -85,3 +85,7 @@ def verify_password_reset_token(token, max_age=3600):  # 1 hour expiration
         return user_id
     except (BadSignature, SignatureExpired):
         return None
+
+
+# Microsoft OAuth: PKCE is now handled by frontend MSAL library.
+# Backend validates Microsoft Bearer tokens via MicrosoftBearerAuthentication class.

--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -20,7 +20,7 @@ from apps.authentication.serializers import (
     MFASetupConfirmSerializer,
     MFASetupStartSerializer,
     MFAVerifySerializer,
-    MicrosoftAuthCallbackSerializer,
+    MicrosoftAuthTokenSerializer,
     PasswordChangeSerializer,
     PasswordResetConfirmSerializer,
     PasswordResetRequestSerializer,
@@ -322,20 +322,24 @@ class MicrosoftAuthStartView(APIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
-class MicrosoftAuthCallbackView(APIView):
-    """Handle Microsoft OAuth callback - exchanges code for tokens and authenticates user."""
+class MicrosoftAuthTokenView(APIView):
+    """Exchange Microsoft authorization code for JWT tokens.
+
+    Frontend receives the authorization code from Microsoft redirect,
+    then POSTs it here to exchange for tokens securely.
+    """
 
     permission_classes = [AllowAny]
     authentication_classes = []
-    serializer_class = MicrosoftAuthCallbackSerializer
+    serializer_class = MicrosoftAuthTokenSerializer
 
     def post(self, request):
-        """Handle callback via POST (recommended for SPA flow)."""
+        """Exchange authorization code for tokens."""
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         code = serializer.validated_data["code"]
-        state = serializer.validated_data.get("state")
+        state = serializer.validated_data["state"]
 
         data = handle_microsoft_callback(code, state)
 
@@ -347,62 +351,3 @@ class MicrosoftAuthCallbackView(APIView):
         response = Response(data, status=status.HTTP_200_OK)
         set_refresh_cookie(response, data.get("refresh"), request)
         return response
-
-    def get(self, request):
-        """Handle callback via GET (Microsoft redirect)."""
-        code = request.query_params.get("code")
-        state = request.query_params.get("state")
-        error = request.query_params.get("error")
-        error_description = request.query_params.get("error_description")
-
-        # Handle error from Microsoft
-        if error:
-            frontend_url = settings.FRONTEND_URL
-            error_params = f"?error={error}&error_description={error_description or 'Authentication failed'}"
-            from django.shortcuts import redirect
-
-            return redirect(f"{frontend_url}/auth/microsoft/callback{error_params}")
-
-        if not code:
-            return Response({"error": "Authorization code not provided"}, status=status.HTTP_400_BAD_REQUEST)
-
-        try:
-            data = handle_microsoft_callback(code, state)
-
-            # For development/testing: return JSON if no frontend
-            # In production, set FRONTEND_URL and this will redirect
-            frontend_url = settings.FRONTEND_URL
-            if not frontend_url or frontend_url == "http://localhost:3000":
-                # Return JSON response for testing (no frontend running)
-                response = Response(data, status=status.HTTP_200_OK)
-                set_refresh_cookie(response, data.get("refresh"), request)
-                return response
-
-            # Check if MFA is required
-            if data.get("mfa_required"):
-                # Redirect to frontend with MFA ticket
-                mfa_ticket = data.get("mfa_ticket")
-                mfa_type = data.get("mfa_type")
-                from django.shortcuts import redirect
-
-                return redirect(f"{frontend_url}/auth/mfa?ticket={mfa_ticket}&type={mfa_type}")
-
-            # Redirect to frontend with tokens (access token in URL, refresh in cookie)
-            from django.shortcuts import redirect
-
-            access_token = data.get("access")
-            response = redirect(f"{frontend_url}/auth/microsoft/callback?access_token={access_token}")
-            set_refresh_cookie(response, data.get("refresh"), request)
-            return response
-
-        except (ValueError, KeyError) as e:
-            frontend_url = settings.FRONTEND_URL
-            if not frontend_url or frontend_url == "http://localhost:3000":
-                # Return JSON error for testing
-                return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-            from urllib.parse import quote
-
-            from django.shortcuts import redirect
-
-            return redirect(f"{frontend_url}/auth/microsoft/callback?error={quote(str(e))}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -134,6 +134,7 @@ REST_FRAMEWORK = {
     "DATETIME_FORMAT": "%Y-%m-%dT%H:%M:%SZ",
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "apps.authentication.authentication.MicrosoftBearerAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
@@ -249,10 +250,10 @@ REDIS_PORT = env("REDIS_PORT", default=6379, cast=int)
 MFA_FERNET_KEY = env("MFA_FERNET_KEY", default="")
 
 # Microsoft OAuth Settings
-MICROSOFT_CLIENT_ID = env("MICROSOFT_CLIENT_ID", default="")
-MICROSOFT_CLIENT_SECRET = env("MICROSOFT_CLIENT_SECRET", default="")
-MICROSOFT_TENANT_ID = env("MICROSOFT_TENANT_ID", default="common")
-MICROSOFT_REDIRECT_URI = env("MICROSOFT_REDIRECT_URI", default="http://localhost:8000/auth/microsoft/callback")
+# Frontend handles full OAuth flow via MSAL. Backend only validates Bearer tokens.
+MICROSOFT_CLIENT_ID = env("MICROSOFT_CLIENT_ID", default="")  # Required: App (client) ID from Azure
+MICROSOFT_TENANT_ID = env("MICROSOFT_TENANT_ID", default="common")  # Required: Directory (tenant) ID
+MICROSOFT_API_AUDIENCE = env("MICROSOFT_API_AUDIENCE", default="")  # Optional: Custom API audience
 
 # Frontend URL for redirects after OAuth
-FRONTEND_URL = env("FRONTEND_URL", default="http://localhost:3000")
+FRONTEND_URL = env("FRONTEND_URL", default="http://localhost:8080")


### PR DESCRIPTION
Added:
  - MicrosoftBearerAuthentication class in apps/authentication/authentication.py
  - Validates Microsoft access tokens via JWKS (JSON Web Key Set)
  - Caches Microsoft public keys in Redis (1 hour TTL)
  - Validates token signature, issuer, audience, and expiry
  - Maps token claims to local user
  - upsert_microsoft_user() service function for user creation/update from token claims

Removed:
  - /auth/microsoft/ endpoint (was for generating auth URL)
  - /auth/microsoft/token/ endpoint (was for code exchange)
  - MicrosoftAuthStartView and MicrosoftAuthTokenView views
  - MicrosoftAuthTokenSerializer serializer

The architecture corresponds to the diagram from the Microsoft Documentation website.
<img width="916" height="586" alt="Screenshot 2025-12-10 190917" src="https://github.com/user-attachments/assets/b25f0325-2fd3-4dca-baa0-167ebfeaa723" />
